### PR TITLE
중복을 피하기 위한 상속의 잘못 된 예시

### DIFF
--- a/src/main/java/mingtoy/domain/music/PersonalPlayList.java
+++ b/src/main/java/mingtoy/domain/music/PersonalPlayList.java
@@ -1,0 +1,10 @@
+package mingtoy.domain.music;
+
+public class PersonalPlayList extends PlayList {
+
+    public void remove(Song song) {
+
+        getSongs().remove(song);
+        getPersonalList().remove(song.getTitle());
+    }
+}

--- a/src/main/java/mingtoy/domain/music/PlayList.java
+++ b/src/main/java/mingtoy/domain/music/PlayList.java
@@ -1,0 +1,20 @@
+package mingtoy.domain.music;
+
+import lombok.Getter;
+
+import java.util.HashMap;
+import java.util.List;
+
+@Getter
+public class PlayList {
+
+    private List<Song>              songs;
+    private HashMap<String, String> personalList;
+
+    public void add(Song song) {
+
+        songs.add(song);
+        personalList.put(song.getTitle(), song.getSinger());
+    }
+
+}

--- a/src/main/java/mingtoy/domain/music/Song.java
+++ b/src/main/java/mingtoy/domain/music/Song.java
@@ -1,0 +1,10 @@
+package mingtoy.domain.music;
+
+import lombok.Getter;
+
+@Getter
+public class Song {
+
+    private String title;
+    private String singer;
+}

--- a/src/test/java/mingtoy/WrongInheritanceTest.java
+++ b/src/test/java/mingtoy/WrongInheritanceTest.java
@@ -1,0 +1,42 @@
+package mingtoy;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+
+public class WrongInheritanceTest {
+
+    public class InstrumentHashSet<E> extends HashSet<E> {
+
+        private Long collectionCount = 0L;
+
+        @Override
+        public boolean add(E e) {
+
+            collectionCount++;
+            return super.add(e);
+        }
+
+        @Override
+        public boolean addAll(Collection<? extends E> e) {
+
+            collectionCount = collectionCount + e.size();
+            return super.addAll(e);
+        }
+    }
+
+    @Test
+    public void overrideExample() {
+
+        InstrumentHashSet<String> testSet = new InstrumentHashSet<String>();
+
+        testSet.addAll(Arrays.asList("abc", "dbf", "efg"));
+
+        // 예상 결과는 3이지만, HashSet의 addAll메소드 내부에서 호출하는 add 메소드는 override 된 InstrumentHashSet의 add를 호출해,
+        // collectionCount를 의도치 않게 증가시키고 있다
+        //assert (testSet.collectionCount == 3);
+        assert (testSet.collectionCount == 6);
+    }
+}


### PR DESCRIPTION
중복을 피하기 위한 상속의 잘못 된 예시